### PR TITLE
Added default remote keyboard and mouse as x2x

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,14 @@ https://github.com/Akilan1999/laplace/tree/keyboard_mouse
 
 
 ### Installation required to share keyboard and mouse
-To do this we ensure that the client either has an IPV6 
-address or a public IPV4 address. 
-We use the popular open repository known as [Barrier KVM](https://github.com/debauchee/barrier). 
+We need to ensure that the client has SSH client installed.
+We use the popular open repository known as [x2x](https://github.com/dottedmag/x2x). 
 
-#### What is Barrier kvm?
+Note: x2x runs on top of SSH. 
 
-Barrier is software that mimics the functionality of a KVM switch, which historically would allow you to use a single keyboard and mouse to control multiple computers by physically turning a dial on the box to switch the machine you're controlling at any given moment. Barrier does this in software, allowing you to tell it which machine to control by moving your mouse to the edge of the screen, or by using a keypress to switch focus to a different system.
-
-#### Barrier KVM build status and links to install 
-|Platform       |Build Status|
-|            --:|:--         |
-|Linux          |[![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Linux%20Build)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)|
-|Mac            |[![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Mac%20Build)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)|
-|Windows Debug  |[![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Windows%20Build&configuration=Windows%20Build%20Debug)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)|
-|Windows Release|[![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Windows%20Build&configuration=Windows%20Build%20Release%20with%20Release%20Installer)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)|
-|Snap           |[![Snap Status](https://build.snapcraft.io/badge/debauchee/barrier.svg)](https://build.snapcraft.io/user/debauchee/barrier)|
+#### What is x2x?
+x2x allows the keyboard, mouse on one X display to be used to control another X
+display. It also shares X clipboards between the displays.
 
 
 ### Build from source
@@ -48,7 +40,6 @@ Barrier is software that mimics the functionality of a KVM switch, which histori
 # Assumes to be running on ubuntu 20.04
 # Ports required to be allocated internally:
 # - 8888 (laplace server)
-# - 24800 (barrier server)
 
 # Updating and installing go compiler
 apt update
@@ -56,8 +47,8 @@ apt install -y golang
 apt install -y jq
 ## Installing git
 apt install -y git
-## Installing barrier
-apt install -y barrier
+## Installing x2x
+apt install -y x2x
 ## Installing chromium
 wget https://github.com/RobRich999/Chromium_Clang/releases/download/v94.0.4585.0-r904940-linux64-deb-avx/chromium-browser-unstable_94.0.4585.0-1_amd64.deb
 apt install -y ./chromium-browser-unstable_94.0.4585.0-1_amd64.deb

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Rooms             string
 	IPAddress         string
 	ScriptToExecute   string
+	SSHPassword       string
 }
 
 // Exists reports whether the named file or directory exists.
@@ -63,6 +64,7 @@ func SetDefaults() error {
 	defaults["Rooms"] = defaultPath + "room.json"
 	defaults["IPAddress"] = "0.0.0.0"
 	defaults["ScriptToExecute"] = ""
+	defaults["SSHPassword"] = ""
 
 	//Paths to search for config file
 	configPaths = append(configPaths, defaultPath)

--- a/core/signal.go
+++ b/core/signal.go
@@ -53,7 +53,20 @@ func GetHttp() *http.ServeMux {
             return
         }
 
-        fmt.Fprintf(w, configResp.BarrierHostName)
+        fmt.Fprintf(w, configResp.SystemUsername)
+    })
+
+    //Get SSH password of the current machine
+    server.HandleFunc("/SSHPassword", func(w http.ResponseWriter, r *http.Request) {
+
+        // Read hostname from config file
+        configResp, err := config.ConfigInit()
+        if err != nil {
+            print(err)
+            return
+        }
+
+        fmt.Fprintf(w, configResp.SSHPassword)
     })
 
     server.HandleFunc("/ws_serve", func(writer http.ResponseWriter, request *http.Request) {

--- a/files/main.html
+++ b/files/main.html
@@ -45,18 +45,18 @@
             <div class="form-group">
                 <input id="inputRoomID" type="text" class="form-control form-control-lg text-center" placeholder="Enter room ID" required>
             </div>
-            <h4>Connect to Barrier KVM (Beta)</h4>
-            <p class="help-text">
-                This is a feature is still on beta testing. This feature will ensure that you can share the keyboard
-                and mouse of the server machine.
-                <br>
-                <span class="text-success font-weight-bold"> Note: This only works if the laplace server has barrierc installed and the room name you are connecting
-                    too belongs to the server.</span>
-            </p>
-            <h6>Host Name: <span id="hostname"> Not detected  </span></h6>
-            <div class="form-group">
-                <input id="barrierIP" type="text" class="form-control form-control-lg text-center" placeholder="IPV6 or IPV4 address">
-            </div>
+<!--            <h4>Connect to Barrier KVM (Beta)</h4>-->
+<!--            <p class="help-text">-->
+<!--                This is a feature is still on beta testing. This feature will ensure that you can share the keyboard-->
+<!--                and mouse of the server machine.-->
+<!--                <br>-->
+<!--                <span class="text-success font-weight-bold"> Note: This only works if the laplace server has barrierc installed and the room name you are connecting-->
+<!--                    too belongs to the server.</span>-->
+<!--            </p>-->
+<!--            <h6>Host Name: <span id="hostname"> Not detected  </span></h6>-->
+<!--            <div class="form-group">-->
+<!--                <input id="barrierIP" type="text" class="form-control form-control-lg text-center" placeholder="IPV6 or IPV4 address">-->
+<!--            </div>-->
             <button type="submit" class="btn btn-dark btn-block" value="submit">Join</button>
         </form>
     </div>
@@ -145,6 +145,18 @@
     </div>
     <hr>
     <div>
+        <h4>Use keyboard and mouse</h4>
+        <p>
+            Ensure you have an SSH client installed on your machine
+        </p>
+        <h4>Run the following command on terminal:</h4>
+        <p>ssh -XC <span id="Username"></span>@<span id="IP"></span> x2x -west -to :0.0</p>
+        <p>Password: <span id="SSHPassword"></span></p>
+        <p class="help-text">
+            Move your mouse to the west, and you should have access to the other computer.
+        </p>
+
+
         <h6>Status</h6>
         <table class="table table-borderless table-sm table-meta">
             <tr>

--- a/files/static/main.js
+++ b/files/static/main.js
@@ -144,6 +144,9 @@ function initUI() {
     LaplaceVar.ui.videoContainer = document.getElementById('video-container');
     LaplaceVar.ui.barrierIP = document.getElementById('barrierIP');
     LaplaceVar.ui.barrierhostname = document.getElementById('hostname');
+    LaplaceVar.ui.serverUsername = document.getElementById('Username');
+    LaplaceVar.ui.serverIP = document.getElementById('IP');
+    LaplaceVar.ui.SSHPassword = document.getElementById('SSHPassword')
     LaplaceVar.headless = { result :"0"};
 
     LaplaceVar.ui.joinForm.onsubmit = async e => {
@@ -197,7 +200,10 @@ function initUI() {
     }
 
     //getting server hostname
-    getServerHostName()
+    getServerIPandHostname()
+
+    //getting SSHPassword
+    getSSHPassword()
 
     // Getting query string from the URL
     const queryString = window.location.search;
@@ -221,14 +227,28 @@ function initUI() {
 // This is so that user can
 // add the host name to connect
 // to laplace
-function getServerHostName() {
+function getServerIPandHostname() {
     // Source https://stackoverflow.com/questions/247483/http-get-request-in-javascript
     var xmlHttp = new XMLHttpRequest()
     xmlHttp.open( "GET", getHttpUrl() + "/hostname", false ); // false for synchronous request
     xmlHttp.send(null);
-    LaplaceVar.ui.barrierhostname.innerHTML = xmlHttp.responseText
+    //LaplaceVar.ui.barrierhostname.innerHTML = xmlHttp.responseText
+    LaplaceVar.ui.serverUsername.innerHTML = xmlHttp.responseText
+
+    // Server IP address
+    LaplaceVar.ui.serverIP.innerHTML = window.location.hostname
     //console.log(window.location.href.split('?')[0])
 }
+
+function getSSHPassword() {
+    // Source https://stackoverflow.com/questions/247483/http-get-request-in-javascript
+    var xmlHttp = new XMLHttpRequest()
+    xmlHttp.open( "GET", getHttpUrl() + "/SSHPassword", false ); // false for synchronous request
+    xmlHttp.send(null);
+
+    LaplaceVar.ui.SSHPassword.innerHTML = xmlHttp.responseText
+}
+
 
 function updateStatusUIStream() {
     LaplaceVar.status.peers = Object.keys(LaplaceVar.pcs).map(s => s.split('$')[1]);
@@ -592,6 +612,7 @@ function routeByUrl() {
 function AddRoomID(roomID) {
     document.getElementById('inputRoomID').value = roomID
 }
+
 function leaveRoom() {
     window.location.href = getBaseUrl();
 }


### PR DESCRIPTION
## What is x2x?
x2x allows the keyboard, mouse on one X display to be used to control another X
display. It also shares X clipboards between the displays.

### Installation required to share keyboard and mouse
We need to ensure that the client has SSH client installed.
We use the popular open repository known as [x2x](https://github.com/dottedmag/x2x).

Note: x2x runs on top of SSH.  